### PR TITLE
Update Panorama.py

### DIFF
--- a/Packs/PAN-OS/Integrations/Panorama/Panorama.py
+++ b/Packs/PAN-OS/Integrations/Panorama/Panorama.py
@@ -11219,7 +11219,7 @@ def main():
             panorama_query_logs_command(args)
 
         elif command == 'panorama-check-logs-status' or command == 'pan-os-check-logs-status':
-            panorama_check_logs_status_command(args)
+            panorama_check_logs_status_command(args.get('job_id'))
 
         elif command == 'panorama-get-logs' or command == 'pan-os-get-logs':
             panorama_get_logs_command(args)


### PR DESCRIPTION
Change made to line 11222, replaced panorama_check_logs_status_command(args) with: panorama_check_logs_status_command(args.get('job_id')). This prevents error when passing job_id variable to panorama_get_traffic_logs(), where a string is now passed instead of a dictionary.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.
This pull request is to fix an error when running the `!pan-os-check-logs-status` command, which results in an 'Invalid Job ID error: No such query job' error. 
Error is due to an an invalid dictionary parameter that is being passed to panorama_get_traffic_logs(), when it should be a string. This code update, fixes this issue.

## Screenshots
Paste here any images that will help the reviewer
![PANOS-Integration Before](https://user-images.githubusercontent.com/102751253/179605965-3212d82c-18fa-47f9-869b-fa8423346991.png)
![PANOS-Integration After](https://user-images.githubusercontent.com/102751253/179605977-660095d4-3ba3-4f1a-8a34-f1f06f12df5a.PNG)
## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [x] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 

